### PR TITLE
feat:completed adding hint system to the game

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -4,9 +4,11 @@ interface CardProps {
   card: CardType;
   onClick: (id: number) => void;
   disabled: boolean;
+  isHighlighted?: boolean;
+  isShaking?: boolean;
 }
 
-export const Card = ({ card, onClick, disabled }: CardProps) => {
+export const Card = ({ card, onClick, disabled, isHighlighted, isShaking }: CardProps) => {
   const handleClick = () => {
     if (!disabled && !card.isFlipped && !card.isMatched) {
       onClick(card.id);
@@ -20,6 +22,8 @@ export const Card = ({ card, onClick, disabled }: CardProps) => {
         relative w-full aspect-square cursor-pointer
         transition-transform duration-200 hover:scale-105 theme-transition
         ${disabled || card.isMatched ? 'cursor-default' : 'cursor-pointer'}
+        ${isHighlighted ? 'hint-glow' : ''}
+        ${isShaking ? 'hint-shake' : ''}
       `}
     >
       <div

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -15,6 +15,12 @@ export const GameBoard = () => {
   const [moves, setMoves] = useState(0);
   const [gameStatus, setGameStatus] = useState<GameStatus>('playing');
   const [isChecking, setIsChecking] = useState(false);
+  // Hint state
+  const [hintsLeft, setHintsLeft] = useState(3);
+  const [isHintOnCooldown, setIsHintOnCooldown] = useState(false);
+  const [hintCooldownMs, setHintCooldownMs] = useState(0);
+  const [highlightedIds, setHighlightedIds] = useState<number[]>([]);
+  const [shakingIds, setShakingIds] = useState<number[]>([]);
 
   useEffect(() => {
     initializeGame();
@@ -39,6 +45,11 @@ export const GameBoard = () => {
     setMoves(0);
     setGameStatus('playing');
     setIsChecking(false);
+    setHintsLeft(3);
+    setIsHintOnCooldown(false);
+    setHintCooldownMs(0);
+    setHighlightedIds([]);
+    setShakingIds([]);
   };
 
   const handleCardClick = (id: number) => {
@@ -82,6 +93,95 @@ export const GameBoard = () => {
     }
   };
 
+  // Utility: find a random unmatched pair's ids
+  const findRandomUnmatchedPair = (): [number, number] | null => {
+    const unmatchedBySymbol: Record<string, number[]> = {};
+    for (const c of cards) {
+      if (c.isMatched) continue;
+      if (!unmatchedBySymbol[c.symbol]) unmatchedBySymbol[c.symbol] = [];
+      unmatchedBySymbol[c.symbol].push(c.id);
+    }
+    const candidatePairs: [number, number][] = [];
+    Object.values(unmatchedBySymbol).forEach(ids => {
+      if (ids.length >= 2) {
+        // collect all combinations in pairs
+        for (let i = 0; i < ids.length; i++) {
+          for (let j = i + 1; j < ids.length; j++) {
+            candidatePairs.push([ids[i], ids[j]]);
+          }
+        }
+      }
+    });
+    if (candidatePairs.length === 0) return null;
+    return candidatePairs[Math.floor(Math.random() * candidatePairs.length)];
+  };
+
+  // Hint actions
+  const runHintPeek = () => {
+    const pair = findRandomUnmatchedPair();
+    if (!pair) return;
+    const [a, b] = pair;
+    // temporarily flip them for 2s
+    const newCards = cards.map(card =>
+      card.id === a || card.id === b ? { ...card, isFlipped: true } : card
+    );
+    setCards(newCards);
+    setIsChecking(true);
+    setTimeout(() => {
+      setCards(prev => prev.map(card =>
+        card.id === a || card.id === b ? { ...card, isFlipped: card.isMatched ? true : false } : card
+      ));
+      setIsChecking(false);
+    }, 2000);
+  };
+
+  const runHintHighlight = () => {
+    const pair = findRandomUnmatchedPair();
+    if (!pair) return;
+    const [a, b] = pair;
+    setHighlightedIds([a, b]);
+    setTimeout(() => setHighlightedIds([]), 2000);
+  };
+
+  const runHintShake = () => {
+    const pair = findRandomUnmatchedPair();
+    if (!pair) return;
+    const [a, b] = pair;
+    setShakingIds([a, b]);
+    setTimeout(() => setShakingIds([]), 1200);
+  };
+
+  const startHintCooldown = (ms: number) => {
+    setIsHintOnCooldown(true);
+    setHintCooldownMs(ms);
+    const start = Date.now();
+    const interval = setInterval(() => {
+      const elapsed = Date.now() - start;
+      const remaining = Math.max(ms - elapsed, 0);
+      setHintCooldownMs(remaining);
+      if (remaining === 0) {
+        clearInterval(interval);
+        setIsHintOnCooldown(false);
+      }
+    }, 250);
+  };
+
+  const handleUseHint = () => {
+    if (isChecking || isHintOnCooldown || hintsLeft <= 0) return;
+
+    // rotate through hint types for variety: peek -> highlight -> shake
+    const hintIndex = (3 - hintsLeft) % 3;
+    if (hintIndex === 0) runHintPeek();
+    else if (hintIndex === 1) runHintHighlight();
+    else runHintShake();
+
+    // penalty: +1 move
+    setMoves(prev => prev + 1);
+
+    setHintsLeft(prev => Math.max(prev - 1, 0));
+    startHintCooldown(5000); // 5s cooldown
+  };
+
   return (
     <div className="w-full max-w-2xl mx-auto px-4">
       <h1 className="text-5xl font-bold text-center mb-2 text-theme-primary theme-transition">
@@ -91,7 +191,15 @@ export const GameBoard = () => {
         Find all matching pairs to win!
       </p>
 
-      <Stats moves={moves} onReset={initializeGame} />
+      <Stats
+        moves={moves}
+        onReset={initializeGame}
+        hintsLeft={hintsLeft}
+        onHintClick={handleUseHint}
+        isHintOnCooldown={isHintOnCooldown}
+        hintCooldownMs={hintCooldownMs}
+        penaltyText={"Using hint adds +1 move"}
+      />
 
       <div className="grid grid-cols-4 gap-4 mb-8">
         {cards.map(card => (
@@ -100,6 +208,8 @@ export const GameBoard = () => {
             card={card}
             onClick={handleCardClick}
             disabled={isChecking}
+            isHighlighted={highlightedIds.includes(card.id)}
+            isShaking={shakingIds.includes(card.id)}
           />
         ))}
       </div>

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,4 +1,4 @@
-import { RotateCcw } from 'lucide-react';
+import { RotateCcw, Lightbulb } from 'lucide-react';
 
 // TODO: Add timer display showing elapsed time
 // TODO: Add best score display from localStorage or Supabase
@@ -6,9 +6,14 @@ import { RotateCcw } from 'lucide-react';
 interface StatsProps {
   moves: number;
   onReset: () => void;
+  hintsLeft?: number;
+  onHintClick?: () => void;
+  isHintOnCooldown?: boolean;
+  hintCooldownMs?: number;
+  penaltyText?: string;
 }
 
-export const Stats = ({ moves, onReset }: StatsProps) => {
+export const Stats = ({ moves, onReset, hintsLeft, onHintClick, isHintOnCooldown, hintCooldownMs, penaltyText }: StatsProps) => {
   return (
     <div className="flex items-center justify-between gap-6 mb-8">
       <div className="bg-theme-secondary rounded-xl shadow-theme px-6 py-3 flex items-center gap-3 theme-transition">
@@ -16,13 +21,32 @@ export const Stats = ({ moves, onReset }: StatsProps) => {
         <span className="text-2xl font-bold accent-primary theme-transition">{moves}</span>
       </div>
 
-      <button
-        onClick={onReset}
-        className="bg-theme-secondary hover:bg-theme-tertiary text-theme-primary font-medium px-6 py-3 rounded-xl shadow-theme transition-all duration-200 hover:shadow-lg flex items-center gap-2 theme-transition"
-      >
-        <RotateCcw size={18} />
-        New Game
-      </button>
+      <div className="flex items-center gap-3">
+        {typeof hintsLeft === 'number' && onHintClick && (
+          <button
+            onClick={onHintClick}
+            disabled={isHintOnCooldown || hintsLeft <= 0}
+            className={`bg-theme-secondary hover:bg-theme-tertiary text-theme-primary font-medium px-4 py-3 rounded-xl shadow-theme transition-all duration-200 hover:shadow-lg flex items-center gap-2 theme-transition ${
+              isHintOnCooldown || hintsLeft <= 0 ? 'opacity-60 cursor-not-allowed' : ''
+            }`}
+            title={penaltyText}
+          >
+            <Lightbulb size={18} />
+            Hint ({hintsLeft})
+            {isHintOnCooldown && (
+              <span className="text-theme-secondary text-sm">{Math.ceil((hintCooldownMs ?? 0) / 1000)}s</span>
+            )}
+          </button>
+        )}
+
+        <button
+          onClick={onReset}
+          className="bg-theme-secondary hover:bg-theme-tertiary text-theme-primary font-medium px-6 py-3 rounded-xl shadow-theme transition-all duration-200 hover:shadow-lg flex items-center gap-2 theme-transition"
+        >
+          <RotateCcw size={18} />
+          New Game
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -121,6 +121,16 @@
   .theme-transition {
     transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
   }
+
+  /* Hint utilities */
+  .hint-glow {
+    position: relative;
+    box-shadow: 0 0 0 3px rgba(250, 204, 21, 0.8), 0 0 18px rgba(250, 204, 21, 0.9);
+  }
+
+  .hint-shake {
+    animation: hintShake 0.8s ease-in-out infinite;
+  }
 }
 
 @keyframes fadeIn {
@@ -141,4 +151,12 @@
     opacity: 1;
     transform: scale(1);
   }
+}
+
+@keyframes hintShake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-2px); }
+  40% { transform: translateX(2px); }
+  60% { transform: translateX(-2px); }
+  80% { transform: translateX(2px); }
 }


### PR DESCRIPTION

Closes #4 

## Summary
- Hint button with remaining count, cooldown, and penalty
- Three hint types: Peek (2s reveal), Highlight (glow), Shake (subtle nudge)
- Default 3 hints per game, +1 move penalty on use, 5s cooldown

## Changes
- Logic: rotate hint types, find random unmatched pair, cooldown timer, penalties
- UI: hint button with counter and tooltip; disabled during cooldown/zero hints
- Visuals: `hint-glow` and `hint-shake` utilities and keyframes

## Files
- `src/components/GameBoard.tsx` — hint state/logic, cooldown, penalties, wiring
- `src/components/Stats.tsx` — hint button, counter, cooldown, penalty label
- `src/components/Card.tsx` — supports `isHighlighted` and `isShaking`
- `src/index.css` — hint utilities: `hint-glow`, `hint-shake` + keyframes


## Screenshots
<img width="955" height="952" alt="image" src="https://github.com/user-attachments/assets/23145d99-7d14-402c-be36-9f4e21cdfe52" />


## Checklist
- [x] Runs: `npm run dev`
- [x] Lints: `npm run lint`
- [x] Types: `npm run typecheck`
- [x] No unrelated changes